### PR TITLE
Remove Main storyboard reference

### DIFF
--- a/SabiasQueObjC/Info.plist
+++ b/SabiasQueObjC/Info.plist
@@ -15,11 +15,11 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
+                                </dict>
+                        </array>
+                </dict>
+        </dict>
+        <key>UILaunchStoryboardName</key>
+        <string>LaunchScreen</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Remove obsolete reference to Main storyboard in scene configuration
- Specify LaunchScreen as the app's launch storyboard

## Testing
- `xcodebuild -project SabiasQueObjC.xcodeproj -scheme SabiasQueObjC test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf9237870832aa95232eff7ab7332