### PR TITLE
Fix crash caused by missing Main storyboard

### DIFF
--- a/SabiasQueObjC.xcodeproj/project.pbxproj
+++ b/SabiasQueObjC.xcodeproj/project.pbxproj
@@ -151,7 +151,6 @@
 				INFOPLIST_FILE = SabiasQueObjC/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 13;
@@ -186,7 +185,6 @@
 				INFOPLIST_FILE = SabiasQueObjC/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 13;


### PR DESCRIPTION
## Summary
- remove main storyboard setting from project build configurations to avoid missing bundle at runtime

## Testing
- `xcodebuild -scheme SabiasQueObjC -sdk iphonesimulator -quiet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bfa6da804832a92aecff8901b4846